### PR TITLE
add api: API_KIND_USER_CANCEL

### DIFF
--- a/lib/gmo-payment-carrier/const.rb
+++ b/lib/gmo-payment-carrier/const.rb
@@ -33,6 +33,10 @@ module GMOPaymentCarrier
           path: '/payment/DocomoContinuanceShopEnd.idPass',
           method: :post
         }
+        h[GMOPaymentCarrier::Docomo::Const::API_KIND_USER_CANCEL] = {
+          path: '/payment/DocomoContinuanceUserEnd.idPass',
+          method: :post
+        }
         h[GMOPaymentCarrier::Docomo::Const::API_KIND_SEARCH] = {
           path: '/payment/SearchTradeMulti.idPass',
           method: :post

--- a/lib/gmo-payment-carrier/docomo/const.rb
+++ b/lib/gmo-payment-carrier/docomo/const.rb
@@ -2,15 +2,17 @@ module GMOPaymentCarrier
   module Docomo
     module Const
       # API種別
-      API_KIND_ENTRY  = :entry_tran_docomo_continuance
-      API_KIND_EXEC   = :exec_tran_docomo_continuance
-      API_KIND_CANCEL = :docomo_continuance_shop_end
-      API_KIND_SEARCH = :docomo_search
+      API_KIND_ENTRY       = :entry_tran_docomo_continuance
+      API_KIND_EXEC        = :exec_tran_docomo_continuance
+      API_KIND_CANCEL      = :docomo_continuance_shop_end
+      API_KIND_USER_CANCEL = :docomo_continuance_user_end
+      API_KIND_SEARCH      = :docomo_search
 
       API_KINDS = [
         API_KIND_ENTRY,
         API_KIND_EXEC,
         API_KIND_CANCEL,
+        API_KIND_USER_CANCEL,
         API_KIND_SEARCH
       ]
 

--- a/lib/gmo-payment-carrier/docomo/validator.rb
+++ b/lib/gmo-payment-carrier/docomo/validator.rb
@@ -9,6 +9,8 @@ module GMOPaymentCarrier
           validate_exec(record)
         when Const::API_KIND_CANCEL
           validate_cancel(record)
+        when Const::API_KIND_USER_CANCEL
+          validate_user_cancel(record)
         when Const::API_KIND_SEARCH
           validate_search(record)
         else
@@ -55,6 +57,22 @@ module GMOPaymentCarrier
               :access_id,
               :access_pass,
               :order_id
+            ]
+          )
+        end
+
+        def validate_user_cancel(record)
+          validate_presence(
+            record,
+            [
+              :shop_id,
+              :shop_pass,
+              :access_id,
+              :access_pass,
+              :order_id,
+              :amount,
+              :ret_url,
+              :last_month_free_flag
             ]
           )
         end

--- a/spec/gmo-payment-carrier/client_spec.rb
+++ b/spec/gmo-payment-carrier/client_spec.rb
@@ -338,6 +338,42 @@ describe GMOPaymentCarrier::Client do
         end
       end
 
+      context "docomo_continuance_user_end" do
+        let(:parameter) do
+          GMOPaymentCarrier::Docomo::Parameter.new(
+            api_kind: GMOPaymentCarrier::Docomo::Const::API_KIND_USER_CANCEL
+          )
+        end
+
+        it 'return success' do
+          response = double('response')
+          body = "OrderID=#{order_id}&Status=#{status}"
+          allow(response).to receive(:more_than_400?).and_return(false)
+          allow(response).to receive(:body).and_return(body)
+          allow(http_client).to receive(:post).and_return(response)
+          allow(client).to receive(:http_client).and_return(http_client)
+
+          parameter.shop_id = shop_id
+          parameter.shop_pass = shop_pass
+          parameter.access_id = access_id
+          parameter.access_pass = access_pass
+          parameter.order_id = order_id
+          parameter.amount = 100
+          parameter.ret_url = ret_url
+          parameter.last_month_free_flag = GMOPaymentCarrier::Docomo::Const::LAST_MONTH_FREE_FLAG_OFF
+
+          result = client.call_api(parameter)
+          expect(result.order_id).to eq(order_id)
+          expect(result.status).to eq(status)
+          expect(result.err_code.blank?).to be true
+          expect(result.err_info.blank?).to be true
+        end
+
+        it 'return ValidationError' do
+          expect { client.call_api(parameter) }.to raise_error(GMOPaymentCarrier::ValidationError)
+        end
+      end
+
       context "docomo_search" do
         let(:parameter) do
           GMOPaymentCarrier::Docomo::Parameter.new(

--- a/spec/gmo-payment-carrier/docomo/parameter_spec.rb
+++ b/spec/gmo-payment-carrier/docomo/parameter_spec.rb
@@ -106,4 +106,47 @@ describe GMOPaymentCarrier::AU::Parameter do
       expect(target.errors[:order_id].blank?).to be true
     end
   end
+
+  describe 'docomo_continuance_user_end' do
+    let(:target) do
+      GMOPaymentCarrier::Docomo::Parameter.new(
+        api_kind: GMOPaymentCarrier::Docomo::Const::API_KIND_USER_CANCEL
+      )
+    end
+
+    it 'docomo_continuance_user_end parameter invalid' do
+      target.valid?
+
+      expect(target.errors[:shop_id].present?).to be true
+      expect(target.errors[:shop_pass].present?).to be true
+      expect(target.errors[:access_id].present?).to be true
+      expect(target.errors[:access_pass].present?).to be true
+      expect(target.errors[:order_id].present?).to be true
+      expect(target.errors[:amount].present?).to be true
+      expect(target.errors[:ret_url].present?).to be true
+      expect(target.errors[:last_month_free_flag].present?).to be true
+    end
+
+    it 'docomo_continuance_user_end parameter valid' do
+      target.shop_id = 'dummmy shop_id'
+      target.shop_pass = 'dummmy shop_pass'
+      target.access_id = 'dummmy access_id'
+      target.access_pass = 'dummmy access_pass'
+      target.order_id = 'dummmy order_id'
+      target.amount = 'dummy amount'
+      target.ret_url = 'dummy ret_url'
+      target.last_month_free_flag = 'dummy last_month_free_flag'
+
+      target.valid?
+
+      expect(target.errors[:shop_id].blank?).to be true
+      expect(target.errors[:shop_pass].blank?).to be true
+      expect(target.errors[:access_id].blank?).to be true
+      expect(target.errors[:access_pass].blank?).to be true
+      expect(target.errors[:order_id].blank?).to be true
+      expect(target.errors[:amount].blank?).to be true
+      expect(target.errors[:ret_url].blank?).to be true
+      expect(target.errors[:last_month_free_flag].blank?).to be true
+    end
+  end
 end


### PR DESCRIPTION
ドコモの継続課金のキャンセル時に、ドコモの画面へ飛ばすための対応