### PR TITLE
Use docker authenticated pull

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,18 @@
 version: 2
+workflows:
+  version: 2
+  rspec:
+    jobs:
+      - build:
+          context:
+            - docker-hub-creds
 jobs:
   build:
     docker:
       - image: ruby:2.6.5
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASS
 
     steps:
       - checkout


### PR DESCRIPTION
https://circleci.com/docs/2.0/private-images/
Docker Hubが発信元IPに基づいてレート制限を課すようになるためDocker Hubで認証済みのDocker pullsを使用するように修正。