### PR TITLE
Fix URI.escape is obsolete warnings

### DIFF
--- a/lib/gmo-payment-carrier/http/client.rb
+++ b/lib/gmo-payment-carrier/http/client.rb
@@ -46,7 +46,7 @@ module GMOPaymentCarrier
           Response.new(
             connection.send(
               request_method,
-              URI.escape(path),
+              path,
               params,
               headers,
             )


### PR DESCRIPTION
GMOPaymentCarrier::Const::API_INFOS の path が渡されるためエンコードは不要。

https://github.com/pocake/gmo-payment-carrier/blob/2dfe5597fdecf8b59840c0e44c5ae00e9267e27f/lib/gmo-payment-carrier/client.rb#L17